### PR TITLE
Updated link to paper, updated usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # d3-cartogram
 
-This is a JavaScript implementation of [an algoritm to construct continuous area cartograms](http://chrisman.scg.ulaval.ca/G360/dougenik.pdf), by James A. Dougenik, Nicholas R. Chrisman and Duane R. Niemeyer, ©1985 by the Association of American Geographers. It relies heavily on [d3](http://github.com/mbostock/d3) for rendering and [TopoJSON](http://github.com/mbostock/topojson) both for writing and reading topological JSON geodata.
+This is a JavaScript implementation of [an algoritm to construct continuous area cartograms](http://lambert.nico.free.fr/tp/biblio/Dougeniketal1985.pdf), by James A. Dougenik, Nicholas R. Chrisman and Duane R. Niemeyer, ©1985 by the Association of American Geographers. It relies heavily on [d3](http://github.com/mbostock/d3) for rendering and [TopoJSON](http://github.com/mbostock/topojson) both for writing and reading topological JSON geodata.
 
 The [included example](https://github.com/shawnbot/d3-cartogram/blob/master/index.html) combines TopoJSON-encoded and boundaries of the United States from [Natural Earth](http://www.naturalearthdata.com/downloads/110m-cultural-vectors/) with [2011 US Census population estimates](http://www.census.gov/popest/data/state/totals/2011/) to size each state proportionally.

--- a/cartogram.js
+++ b/cartogram.js
@@ -18,7 +18,7 @@
    *    return Math.random() * 100;
    *  });
    * d3.json("path/to/topology.json", function(topology) {
-   *  var features = cartogram(topology);
+   *  var features = cartogram(topology, topology.objects.OBJECTNAME.geometries);
    *  d3.select("svg").selectAll("path")
    *    .data(features)
    *    .enter()


### PR DESCRIPTION
The existing link to the PDF in the readme is dead. The usage instructions in cartogram.js leave out the need to reference the necessary geometries.
